### PR TITLE
팀스페이스 api 연결

### DIFF
--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+
 import { TEAMAPI } from '../config/api';
 
 const teamAPI = {
@@ -16,9 +17,14 @@ const teamAPI = {
     return res.data;
   },
 
-  lodgingList: async (token) => {
-    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
-    const res = await axios.get(TEAMAPI.TEAMLODGING, headers);
+  lodgingList: async (userToken, teamToken) => {
+    console.log(userToken, teamToken);
+    const headers = userToken
+      ? { headers: { Authorization: `Token ${userToken}` } }
+      : { headers: {} };
+
+    const params = { params: teamToken };
+    const res = await axios.get(TEAMAPI.TEAMLODGING, params, headers);
 
     return res.data;
   },

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -15,6 +15,20 @@ const teamAPI = {
 
     return res.data;
   },
+
+  lodgingList: async (token) => {
+    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
+    const res = await axios.get(TEAMAPI.TEAMLODGING, headers);
+
+    return res.data;
+  },
+
+  lodgingCreate: async (payload, token) => {
+    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
+    const res = await axios.post(TEAMAPI.TEAMLODGING, payload, headers);
+
+    return res.data;
+  },
 };
 
 export default teamAPI;

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -29,6 +29,20 @@ const teamAPI = {
 
     return res.data;
   },
+
+  recreaitonList: async (token) => {
+    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
+    const res = await axios.get(TEAMAPI.TEAMRECREATION, headers);
+
+    return res.data;
+  },
+
+  recreaitonCreate: async (payload, token) => {
+    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
+    const res = await axios.post(TEAMAPI.TEAMRECREATION, payload, headers);
+
+    return res.data;
+  },
 };
 
 export default teamAPI;

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -51,6 +51,24 @@ const teamAPI = {
 
     return res.data;
   },
+
+  shoppingList: async (userToken, teamToken) => {
+    const headers = userToken
+      ? { headers: { Authorization: `Token ${userToken}` } }
+      : { headers: {} };
+    const params = { params: teamToken };
+    console.log(headers);
+    const res = await axios.get(TEAMAPI.TEAMSHOPPING, params, headers);
+
+    return res.data;
+  },
+
+  shoppingCreate: async (payload, token) => {
+    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
+    const res = await axios.post(TEAMAPI.TEAMSHOPPING, payload, headers);
+
+    return res.data;
+  },
 };
 
 export default teamAPI;

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -18,7 +18,6 @@ const teamAPI = {
   },
 
   lodgingList: async (userToken, teamToken) => {
-    console.log(userToken, teamToken);
     const headers = userToken
       ? { headers: { Authorization: `Token ${userToken}` } }
       : { headers: {} };
@@ -36,9 +35,13 @@ const teamAPI = {
     return res.data;
   },
 
-  recreaitonList: async (token) => {
-    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
-    const res = await axios.get(TEAMAPI.TEAMRECREATION, headers);
+  recreaitonList: async (userToken, teamToken) => {
+    const headers = userToken
+      ? { headers: { Authorization: `Token ${userToken}` } }
+      : { headers: {} };
+    const params = { params: teamToken };
+
+    const res = await axios.get(TEAMAPI.TEAMRECREATION, params, headers);
 
     return res.data;
   },

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -10,6 +10,13 @@ const teamAPI = {
     return res.data;
   },
 
+  join: async (payload, token) => {
+    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
+    const res = await axios.post(TEAMAPI.JOIN, payload, headers);
+
+    return res.data;
+  },
+
   create: async (name, token) => {
     const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
     const res = await axios.post(TEAMAPI.TEAM, name, headers);

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -22,8 +22,16 @@ const teamAPI = {
       ? { headers: { Authorization: `Token ${userToken}` } }
       : { headers: {} };
     const params = { params: teamToken };
-
     const res = await axios.get(TEAMAPI.TEAMLODGING, params, headers);
+
+    return res.data;
+  },
+
+  lodgingScrapList: async (userToken, lodgingPk) => {
+    const res = await axios.get(TEAMAPI.LODGING_IS_SCRAP, {
+      params: { lodgingPk },
+      headers: { Authorization: `Token ${userToken}` },
+    });
 
     return res.data;
   },
@@ -53,12 +61,10 @@ const teamAPI = {
   },
 
   shoppingList: async (userToken, teamToken) => {
-    const headers = userToken
-      ? { headers: { Authorization: `Token ${userToken}` } }
-      : { headers: {} };
-    const params = { params: teamToken };
-    console.log(headers);
-    const res = await axios.get(TEAMAPI.TEAMSHOPPING, params, headers);
+    const res = await axios.get(TEAMAPI.TEAMSHOPPING, {
+      params: { teamToken },
+      headers: { Authorization: `Token ${userToken}` },
+    });
 
     return res.data;
   },

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -53,6 +53,15 @@ const teamAPI = {
     return res.data;
   },
 
+  recreationScrapList: async (userToken, recreationPk) => {
+    const res = await axios.get(TEAMAPI.RECREATION_IS_SCRAP, {
+      params: { recreationPk },
+      headers: { Authorization: `Token ${userToken}` },
+    });
+
+    return res.data;
+  },
+
   recreaitonCreate: async (payload, token) => {
     const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
     const res = await axios.post(TEAMAPI.TEAMRECREATION, payload, headers);

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import { TEAMAPI } from '../config/api';
+
+const teamAPI = {
+  list: async (token) => {
+    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
+    const res = await axios.get(TEAMAPI.TEAM, headers);
+
+    return res.data;
+  },
+
+  create: async (name, token) => {
+    const headers = token ? { headers: { Authorization: `Token ${token}` } } : { headers: {} };
+    const res = await axios.post(TEAMAPI.TEAM, name, headers);
+
+    return res.data;
+  },
+};
+
+export default teamAPI;

--- a/src/apis/teamAPI.js
+++ b/src/apis/teamAPI.js
@@ -21,8 +21,8 @@ const teamAPI = {
     const headers = userToken
       ? { headers: { Authorization: `Token ${userToken}` } }
       : { headers: {} };
-
     const params = { params: teamToken };
+
     const res = await axios.get(TEAMAPI.TEAMLODGING, params, headers);
 
     return res.data;
@@ -40,7 +40,6 @@ const teamAPI = {
       ? { headers: { Authorization: `Token ${userToken}` } }
       : { headers: {} };
     const params = { params: teamToken };
-
     const res = await axios.get(TEAMAPI.TEAMRECREATION, params, headers);
 
     return res.data;

--- a/src/components/Card/BestlocationCard.jsx
+++ b/src/components/Card/BestlocationCard.jsx
@@ -9,6 +9,7 @@ import Heart from '../../assets/images/heart-gray.png';
 import SelectHeart from '../../assets/images/Select_Heart.png';
 import Star from '../../assets/images/star.png';
 import useLodgingScrap from '../../hooks/queries/Lodging/useLodgingScrap';
+import LodingPopup from '../Popup/Lodging/LodingPopup';
 
 const BestLoContainer = styled.div`
   width: 240px;
@@ -70,6 +71,20 @@ const Flex = styled.div`
   align-items: flex-end;
 `;
 
+const TeamBtn = styled.button`
+  padding: 4px 10px;
+  border: 2px solid ${COLOR.lightGray};
+  border-radius: 16px;
+  width: 148px;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+  &:hover {
+    border: 2px solid ${COLOR.primary.blue};
+  }
+`;
+
 /**
  * 카드 컴포넌트 설명
  * @param {number} pk 카드 id
@@ -82,6 +97,9 @@ const Flex = styled.div`
 
 const BestlocationCard = ({ pk, name, price, mainPhoto, avgScore, isScrap }) => {
   const [liked, setLiked] = useState(isScrap);
+  // const [selected, setSelected] = useState('');
+  const [IspopupVisivle, setIspopupVisivle] = useState(false);
+
   const navigate = useNavigate();
 
   const queryClient = useQueryClient();
@@ -104,25 +122,39 @@ const BestlocationCard = ({ pk, name, price, mainPhoto, avgScore, isScrap }) => 
     }
   };
 
+  const handleTeamBtnClick = (e) => {
+    e.stopPropagation();
+    setIspopupVisivle(true);
+  };
+
+  const handlePopupClose = () => {
+    setIspopupVisivle(false);
+  };
+
   // 상세페이지 링크 걸면 됨. (카드누르면 링크 바뀌게만 해둔 상태)
   const handleCardClick = () => {
     navigate(`/lodging/${pk}`, { state: pk });
   };
 
   return (
-    <BestLoContainer onClick={handleCardClick}>
-      <BackDiv $$datasrc={BASE_URL + mainPhoto}>
-        <LikeButton src={liked ? SelectHeart : Heart} alt="Like" onClick={handlelikeClick} />
-      </BackDiv>
-      <Title>{name}</Title>
-      <Flexdirection>
-        <Price>{price} 원</Price>
-        <Flex>
-          <BlueStar src={Star} />
-          <Score>{avgScore}</Score>
-        </Flex>
-      </Flexdirection>
-    </BestLoContainer>
+    <>
+      <BestLoContainer onClick={handleCardClick}>
+        <BackDiv $$datasrc={BASE_URL + mainPhoto}>
+          <LikeButton src={liked ? SelectHeart : Heart} alt="Like" onClick={handlelikeClick} />
+        </BackDiv>
+        <Title>{name}</Title>
+        <Flexdirection>
+          <Price>{price} 원</Price>
+          <Flex>
+            <BlueStar src={Star} />
+            <Score>{avgScore}</Score>
+          </Flex>
+        </Flexdirection>
+
+        <TeamBtn onClick={handleTeamBtnClick}>팀스페이스에 담기</TeamBtn>
+      </BestLoContainer>
+      {IspopupVisivle && <LodingPopup pk={pk} handlePopupClose={handlePopupClose} />}
+    </>
   );
 };
 export default BestlocationCard;

--- a/src/components/Card/BestlocationCard.jsx
+++ b/src/components/Card/BestlocationCard.jsx
@@ -9,7 +9,6 @@ import Heart from '../../assets/images/heart-gray.png';
 import SelectHeart from '../../assets/images/Select_Heart.png';
 import Star from '../../assets/images/star.png';
 import useLodgingScrap from '../../hooks/queries/Lodging/useLodgingScrap';
-import LodingPopup from '../Popup/Lodging/LodingPopup';
 
 const BestLoContainer = styled.div`
   width: 240px;
@@ -71,20 +70,6 @@ const Flex = styled.div`
   align-items: flex-end;
 `;
 
-const TeamBtn = styled.button`
-  padding: 4px 10px;
-  border: 2px solid ${COLOR.lightGray};
-  border-radius: 16px;
-  width: 148px;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    border-color 0.2s;
-  &:hover {
-    border: 2px solid ${COLOR.primary.blue};
-  }
-`;
-
 /**
  * 카드 컴포넌트 설명
  * @param {number} pk 카드 id
@@ -97,7 +82,6 @@ const TeamBtn = styled.button`
 
 const BestlocationCard = ({ pk, name, price, mainPhoto, avgScore, isScrap }) => {
   const [liked, setLiked] = useState(isScrap);
-  const [IspopupVisivle, setIspopupVisivle] = useState(false);
 
   const navigate = useNavigate();
 
@@ -121,38 +105,24 @@ const BestlocationCard = ({ pk, name, price, mainPhoto, avgScore, isScrap }) => 
     }
   };
 
-  const handleTeamBtnClick = (e) => {
-    e.stopPropagation();
-    setIspopupVisivle(true);
-  };
-
-  const handlePopupClose = () => {
-    setIspopupVisivle(false);
-  };
-
   const handleCardClick = () => {
     navigate(`/lodging/${pk}`, { state: pk });
   };
 
   return (
-    <>
-      <BestLoContainer onClick={handleCardClick}>
-        <BackDiv $$datasrc={BASE_URL + mainPhoto}>
-          <LikeButton src={liked ? SelectHeart : Heart} alt="Like" onClick={handlelikeClick} />
-        </BackDiv>
-        <Title>{name}</Title>
-        <Flexdirection>
-          <Price>{price} 원</Price>
-          <Flex>
-            <BlueStar src={Star} />
-            <Score>{avgScore}</Score>
-          </Flex>
-        </Flexdirection>
-
-        <TeamBtn onClick={handleTeamBtnClick}>팀스페이스에 담기</TeamBtn>
-      </BestLoContainer>
-      {IspopupVisivle && <LodingPopup pk={pk} handlePopupClose={handlePopupClose} />}
-    </>
+    <BestLoContainer onClick={handleCardClick}>
+      <BackDiv $$datasrc={BASE_URL + mainPhoto}>
+        <LikeButton src={liked ? SelectHeart : Heart} alt="Like" onClick={handlelikeClick} />
+      </BackDiv>
+      <Title>{name}</Title>
+      <Flexdirection>
+        <Price>{price} 원</Price>
+        <Flex>
+          <BlueStar src={Star} />
+          <Score>{avgScore}</Score>
+        </Flex>
+      </Flexdirection>
+    </BestLoContainer>
   );
 };
 export default BestlocationCard;

--- a/src/components/Card/BestlocationCard.jsx
+++ b/src/components/Card/BestlocationCard.jsx
@@ -97,7 +97,6 @@ const TeamBtn = styled.button`
 
 const BestlocationCard = ({ pk, name, price, mainPhoto, avgScore, isScrap }) => {
   const [liked, setLiked] = useState(isScrap);
-  // const [selected, setSelected] = useState('');
   const [IspopupVisivle, setIspopupVisivle] = useState(false);
 
   const navigate = useNavigate();
@@ -131,7 +130,6 @@ const BestlocationCard = ({ pk, name, price, mainPhoto, avgScore, isScrap }) => 
     setIspopupVisivle(false);
   };
 
-  // 상세페이지 링크 걸면 됨. (카드누르면 링크 바뀌게만 해둔 상태)
   const handleCardClick = () => {
     navigate(`/lodging/${pk}`, { state: pk });
   };

--- a/src/components/Card/RecreationCard.jsx
+++ b/src/components/Card/RecreationCard.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
@@ -8,6 +8,7 @@ import Recreatbtn from '../../assets/images/Recreat.png';
 import SelectRecreat from '../../assets/images/Select_recreat.png';
 import { BASE_URL } from '../../config/api';
 import useRecreationScrap from '../../hooks/queries/Recreation/useRecreationScrap';
+import RecreationPopup from '../Popup/Recreation/RecreationPopup';
 
 const BestLoContainer = styled.div`
   width: 240px;
@@ -63,24 +64,6 @@ const PeopleCount = styled.div`
   color: ${COLOR.lightGray};
 `;
 
-const Teamspace = styled.button`
-  padding: 4px 10px;
-  border: 2px solid ${COLOR.lightGray};
-  border-radius: 16px;
-  width: 148px;
-  transition:
-    background-color 0.2s,
-    border-color 0.2s;
-
-  ${(props) =>
-    props.$teamspace &&
-    css`
-      background-color: ${COLOR.primary.blue};
-      border-color: ${COLOR.primary.blue};
-      color: ${COLOR.white};
-    `}
-`;
-
 const Flex = styled.div`
   display: flex;
   flex-direction: column;
@@ -88,11 +71,26 @@ const Flex = styled.div`
   margin: 17px 10px 10px 10px;
 `;
 
+const TeamBtn = styled.button`
+  padding: 4px 10px;
+  border: 2px solid ${COLOR.lightGray};
+  border-radius: 16px;
+  width: 148px;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+  &:hover {
+    border: 2px solid ${COLOR.primary.blue};
+  }
+`;
+
 // 레크리에이션 카드
 // state : 팀페이스 담기 버튼 / 스크랩 후 사진 / 스크랩 수
 const RecreationCard = ({ pk, name, photo, headCountMin, headCountMax, isScrap }) => {
-  const [teamspace] = useState(false);
   const [save, setSave] = useState(isScrap);
+  const [IspopupVisivle, setIspopupVisivle] = useState(false);
+
   const navigate = useNavigate();
 
   const queryClient = useQueryClient();
@@ -119,29 +117,39 @@ const RecreationCard = ({ pk, name, photo, headCountMin, headCountMax, isScrap }
     navigate(`/recreation/${pk}`, { state: pk });
   };
 
+  const handleTeamBtnClick = (e) => {
+    e.stopPropagation();
+    setIspopupVisivle(true);
+  };
+
+  const handlePopupClose = () => {
+    setIspopupVisivle(false);
+  };
+
   return (
-    <BestLoContainer>
-      <BackContainer onClick={handleCardClick}>
-        <BackImg src={BASE_URL + photo} />
-        <BtnCotainer>
-          <RecreatButton
-            src={save ? SelectRecreat : Recreatbtn}
-            alt="save"
-            onClick={handleSaveClick}
-          />
-          <SaveCount>NN</SaveCount>
-        </BtnCotainer>
-      </BackContainer>
-      <Flex>
-        <Title>{name}</Title>
-        <PeopleCount>
-          추천인원 : {headCountMin} ~ {headCountMax} 명
-        </PeopleCount>
-        <Teamspace $teamspace={teamspace} onClick={handleSaveClick}>
-          팀스페이스 담기
-        </Teamspace>
-      </Flex>
-    </BestLoContainer>
+    <>
+      <BestLoContainer>
+        <BackContainer onClick={handleCardClick}>
+          <BackImg src={BASE_URL + photo} />
+          <BtnCotainer>
+            <RecreatButton
+              src={save ? SelectRecreat : Recreatbtn}
+              alt="save"
+              onClick={handleSaveClick}
+            />
+            <SaveCount>NN</SaveCount>
+          </BtnCotainer>
+        </BackContainer>
+        <Flex>
+          <Title>{name}</Title>
+          <PeopleCount>
+            추천인원 : {headCountMin} ~ {headCountMax} 명
+          </PeopleCount>
+          <TeamBtn onClick={handleTeamBtnClick}>팀스페이스에 담기</TeamBtn>
+        </Flex>
+      </BestLoContainer>
+      {IspopupVisivle && <RecreationPopup pk={pk} handlePopupClose={handlePopupClose} />}
+    </>
   );
 };
 export default RecreationCard;

--- a/src/components/Common/Shopping/ListTable.jsx
+++ b/src/components/Common/Shopping/ListTable.jsx
@@ -68,7 +68,7 @@ const ButtonDiv = styled.div`
   gap: 1rem;
   height: 100%;
 `;
-const ShoppingTable = ({ data, setShoppingItems }) => {
+const ListTable = ({ data, setShoppingItems }) => {
   const [editHandle, setEditHandle] = useState(false);
   const totalSum = data.reduce((acc, item) => acc + item.price * item.amount, 0);
 
@@ -188,4 +188,4 @@ const ShoppingTable = ({ data, setShoppingItems }) => {
     </Container>
   );
 };
-export default ShoppingTable;
+export default ListTable;

--- a/src/components/LodgingDetail/LodgingDetailHeader.jsx
+++ b/src/components/LodgingDetail/LodgingDetailHeader.jsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
-import React from 'react';
+import React, { useState } from 'react';
 import heart from '../../assets/images/heart-gradient.png';
 import booking from '../../assets/images/booking.png';
 import ImageSwiper from '../ImageSwiper/ImageSwiper';
 import COLOR from '../../constants/color';
 import RatingContainer from '../Common/Review/RatingContainer';
+import LodingPopup from '../Popup/Lodging/LodingPopup';
 
 const HeaderContainer = styled.div`
   margin-bottom: 3rem;
@@ -33,11 +34,13 @@ const TitleText = styled.span`
 const Heart = styled.img`
   width: 3.75rem;
   height: 3.75rem;
+  cursor: pointer;
 `;
 
 const Booking = styled.img`
   width: 3.75rem;
   height: 3.75rem;
+  cursor: pointer;
 `;
 
 const LodingDealingContainer = styled.div`
@@ -57,7 +60,18 @@ const ReservationBtn = styled.button`
   color: ${COLOR.white};
 `;
 
-const LodgingDetailHeader = ({ name, mainPhoto, photos }) => {
+const LodgingDetailHeader = ({ pk, name, mainPhoto, photos }) => {
+  const [IspopupVisivle, setIspopupVisivle] = useState(false);
+
+  const handleTeamBtnClick = (e) => {
+    e.stopPropagation();
+    setIspopupVisivle(true);
+  };
+
+  const handlePopupClose = () => {
+    setIspopupVisivle(false);
+  };
+
   return (
     <HeaderContainer>
       <Header>
@@ -66,7 +80,7 @@ const LodgingDetailHeader = ({ name, mainPhoto, photos }) => {
           <LodingDealingContainer>
             <RatingContainer score="4.9" />
             <Heart src={heart} />
-            <Booking src={booking} />
+            <Booking src={booking} onClick={handleTeamBtnClick} />
           </LodingDealingContainer>
           <ReservationBtn width={11.25} height={3.75}>
             예약하기
@@ -74,6 +88,7 @@ const LodgingDetailHeader = ({ name, mainPhoto, photos }) => {
         </HeaderRight>
       </Header>
       <ImageSwiper mainPhoto={mainPhoto} photos={photos} />
+      {IspopupVisivle && <LodingPopup pk={pk} handlePopupClose={handlePopupClose} />}
     </HeaderContainer>
   );
 };

--- a/src/components/Popup/Lodging/LodingPopup.jsx
+++ b/src/components/Popup/Lodging/LodingPopup.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { useQueryClient } from '@tanstack/react-query';
+import Submitbutton from '../../Button/SubmitButton';
+
+import COLOR from '../../../constants/color';
+import close from '../../../assets/images/close.png';
+import useTeam from '../../../hooks/queries/Team/useTeam';
+import Loading from '../../../pages/Loading';
+import Error from '../../../pages/Error';
+import useTeamLodging from '../../../hooks/queries/Team/useTeamLodging';
+
+const PopupBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+`;
+
+const PopupContainer = styled.div`
+  width: 560px;
+  height: 360px;
+  background-color: ${COLOR.white};
+  padding: 1rem;
+  border-radius: 48px;
+`;
+
+const PopupContent = styled.div`
+  padding: 1.3rem 3.6rem;
+  height: 100%;
+`;
+
+const CloseBtn = styled.img`
+  position: fixed;
+  width: 1rem;
+  height: 1rem;
+  color: black;
+  cursor: pointer;
+  position: relative;
+  top: -1.5rem;
+  right: -33.5rem;
+  z-index: 1001;
+`;
+
+const Title = styled.h2`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2.6rem;
+`;
+
+const SubTitle = styled.div`
+  font-size: 20px;
+  margin: 1.5rem 0;
+`;
+
+const TeamList = styled.ul`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 3rem;
+`;
+
+const TeamBtn = styled.div`
+  padding: 4px 10px;
+  border: 2px solid ${COLOR.lightGray};
+  border-radius: 16px;
+  text-align: center;
+  width: 148px;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+  &:hover {
+    border: 2px solid ${COLOR.gray};
+    background: ${COLOR.lightGray};
+  }
+
+  ${(props) =>
+    props.active &&
+    css`
+      background-color: ${COLOR.primary.blue};
+      border-color: ${COLOR.primary.blue};
+      color: ${COLOR.white};
+    `}
+`;
+
+const FlexDiv = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const LodingPopup = ({ pk, handlePopupClose }) => {
+  const queryClient = useQueryClient();
+  const user = queryClient.getQueryData(['user']);
+
+  const {
+    teamQuery: { isLoading: teamIsLoading, error: teamError, data: teams },
+  } = useTeam(user ? user.token : '');
+
+  const { teamLodgingMutation } = useTeamLodging();
+
+  const handleTeamClick = (teamToken) => {
+    teamLodgingMutation({ teamToken, lodgingPk: pk });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    handlePopupClose();
+  };
+  return (
+    <PopupBackground>
+      <PopupContainer>
+        <CloseBtn src={close} onClick={handlePopupClose} />
+        <PopupContent>
+          <Title>팀스페이스 추가하기</Title>
+          <SubTitle>추가할 팀스페이스를 선택해주세요</SubTitle>
+          {teamIsLoading && <Loading />}
+          {teamError && <Error />}
+          <TeamList>
+            {teams &&
+              teams.map((team) => (
+                <TeamBtn
+                  key={team.teamToken}
+                  active={team.teamName === true}
+                  onClick={() => handleTeamClick(team.teamToken)}
+                >
+                  {team.teamName}
+                </TeamBtn>
+              ))}
+          </TeamList>
+          <FlexDiv>
+            <Submitbutton onClick={handleSubmit}>완료</Submitbutton>
+          </FlexDiv>
+        </PopupContent>
+      </PopupContainer>
+    </PopupBackground>
+  );
+};
+
+export default LodingPopup;

--- a/src/components/Popup/Lodging/LodingPopup.jsx
+++ b/src/components/Popup/Lodging/LodingPopup.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useQueryClient } from '@tanstack/react-query';
 import Submitbutton from '../../Button/SubmitButton';
 
 import COLOR from '../../../constants/color';
 import close from '../../../assets/images/close.png';
-import useTeam from '../../../hooks/queries/Team/useTeam';
 import Loading from '../../../pages/Loading';
 import Error from '../../../pages/Error';
 import useTeamLodgingCreate from '../../../hooks/queries/Team/useTeamLodgingCreate';
+import useTeamLodgingScrap from '../../../hooks/queries/Team/useTeamLodgingScrap';
 
 const PopupBackground = styled.div`
   position: fixed;
@@ -71,7 +71,9 @@ const TeamBtn = styled.div`
   padding: 4px 10px;
   border: 2px solid ${COLOR.lightGray};
   border-radius: 16px;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 148px;
   cursor: pointer;
   transition:
@@ -81,6 +83,14 @@ const TeamBtn = styled.div`
     border: 2px solid ${COLOR.gray};
     background: ${COLOR.lightGray};
   }
+
+  ${(props) =>
+    props.isScrap &&
+    css`
+      background-color: ${COLOR.primary.blue};
+      color: ${COLOR.white};
+      border: none;
+    `}
 `;
 
 const FlexDiv = styled.div`
@@ -93,10 +103,10 @@ const LodingPopup = ({ pk, handlePopupClose }) => {
   const user = queryClient.getQueryData(['user']);
 
   const {
-    teamQuery: { isLoading: teamIsLoading, error: teamError, data: teams },
-  } = useTeam(user ? user.token : '');
+    teamLodgingScrapQuery: { isLoading, error, data: teams },
+  } = useTeamLodgingScrap(user ? user.token : '', pk);
 
-  const { teamLodgingMutation } = useTeamLodgingCreate(user ? user.token : '');
+  const { teamLodgingMutation } = useTeamLodgingCreate(user ? user.token : '', pk);
 
   const handleTeamClick = (teamToken) => {
     teamLodgingMutation({ teamToken, lodgingPk: pk });
@@ -114,12 +124,16 @@ const LodingPopup = ({ pk, handlePopupClose }) => {
         <PopupContent>
           <Title>팀스페이스 추가하기</Title>
           <SubTitle>추가할 팀스페이스를 선택해주세요</SubTitle>
-          {teamIsLoading && <Loading />}
-          {teamError && <Error />}
+          {isLoading && <Loading />}
+          {error && <Error />}
           <TeamList>
             {teams &&
               teams.map((team) => (
-                <TeamBtn key={team.teamToken} onClick={() => handleTeamClick(team.teamToken)}>
+                <TeamBtn
+                  key={team.teamToken}
+                  onClick={() => handleTeamClick(team.teamToken)}
+                  isScrap={team.isScrap}
+                >
                   {team.teamName}
                 </TeamBtn>
               ))}

--- a/src/components/Popup/Lodging/LodingPopup.jsx
+++ b/src/components/Popup/Lodging/LodingPopup.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useQueryClient } from '@tanstack/react-query';
 import Submitbutton from '../../Button/SubmitButton';
 
@@ -8,7 +8,7 @@ import close from '../../../assets/images/close.png';
 import useTeam from '../../../hooks/queries/Team/useTeam';
 import Loading from '../../../pages/Loading';
 import Error from '../../../pages/Error';
-import useTeamLodging from '../../../hooks/queries/Team/useTeamLodging';
+import useTeamLodgingCreate from '../../../hooks/queries/Team/useTeamLodgingCreate';
 
 const PopupBackground = styled.div`
   position: fixed;
@@ -81,14 +81,6 @@ const TeamBtn = styled.div`
     border: 2px solid ${COLOR.gray};
     background: ${COLOR.lightGray};
   }
-
-  ${(props) =>
-    props.active &&
-    css`
-      background-color: ${COLOR.primary.blue};
-      border-color: ${COLOR.primary.blue};
-      color: ${COLOR.white};
-    `}
 `;
 
 const FlexDiv = styled.div`
@@ -104,7 +96,7 @@ const LodingPopup = ({ pk, handlePopupClose }) => {
     teamQuery: { isLoading: teamIsLoading, error: teamError, data: teams },
   } = useTeam(user ? user.token : '');
 
-  const { teamLodgingMutation } = useTeamLodging();
+  const { teamLodgingMutation } = useTeamLodgingCreate(user ? user.token : '');
 
   const handleTeamClick = (teamToken) => {
     teamLodgingMutation({ teamToken, lodgingPk: pk });
@@ -127,11 +119,7 @@ const LodingPopup = ({ pk, handlePopupClose }) => {
           <TeamList>
             {teams &&
               teams.map((team) => (
-                <TeamBtn
-                  key={team.teamToken}
-                  active={team.teamName === true}
-                  onClick={() => handleTeamClick(team.teamToken)}
-                >
+                <TeamBtn key={team.teamToken} onClick={() => handleTeamClick(team.teamToken)}>
                   {team.teamName}
                 </TeamBtn>
               ))}

--- a/src/components/Popup/Lodging/LodingPopup.jsx
+++ b/src/components/Popup/Lodging/LodingPopup.jsx
@@ -7,8 +7,8 @@ import COLOR from '../../../constants/color';
 import close from '../../../assets/images/close.png';
 import Loading from '../../../pages/Loading';
 import Error from '../../../pages/Error';
-import useTeamLodgingCreate from '../../../hooks/queries/Team/useTeamLodgingCreate';
 import useTeamLodgingIsScrap from '../../../hooks/queries/Team/useTeamLodgingIsScrap';
+import useTeamLodgingScrap from '../../../hooks/queries/Team/useTeamLodgingScrap';
 
 const PopupBackground = styled.div`
   position: fixed;
@@ -106,7 +106,7 @@ const LodingPopup = ({ pk, handlePopupClose }) => {
     teamLodgingScrapQuery: { isLoading, error, data: teams },
   } = useTeamLodgingIsScrap(user ? user.token : '', pk);
 
-  const { teamLodgingMutation } = useTeamLodgingCreate(user ? user.token : '', pk);
+  const { teamLodgingMutation } = useTeamLodgingScrap(user ? user.token : '', pk);
 
   const handleTeamClick = (teamToken) => {
     teamLodgingMutation({ teamToken, lodgingPk: pk });

--- a/src/components/Popup/Lodging/LodingPopup.jsx
+++ b/src/components/Popup/Lodging/LodingPopup.jsx
@@ -8,7 +8,7 @@ import close from '../../../assets/images/close.png';
 import Loading from '../../../pages/Loading';
 import Error from '../../../pages/Error';
 import useTeamLodgingCreate from '../../../hooks/queries/Team/useTeamLodgingCreate';
-import useTeamLodgingScrap from '../../../hooks/queries/Team/useTeamLodgingScrap';
+import useTeamLodgingIsScrap from '../../../hooks/queries/Team/useTeamLodgingIsScrap';
 
 const PopupBackground = styled.div`
   position: fixed;
@@ -104,7 +104,7 @@ const LodingPopup = ({ pk, handlePopupClose }) => {
 
   const {
     teamLodgingScrapQuery: { isLoading, error, data: teams },
-  } = useTeamLodgingScrap(user ? user.token : '', pk);
+  } = useTeamLodgingIsScrap(user ? user.token : '', pk);
 
   const { teamLodgingMutation } = useTeamLodgingCreate(user ? user.token : '', pk);
 

--- a/src/components/Popup/Mypage/TeamspaceCreatePopup.jsx
+++ b/src/components/Popup/Mypage/TeamspaceCreatePopup.jsx
@@ -71,7 +71,7 @@ const FlexDiv = styled.div`
   justify-content: center;
 `;
 
-const TeamSpacePopup = ({ handlePopupClose }) => {
+const TeamSpaceCreatePopup = ({ handlePopupClose }) => {
   const queryClient = useQueryClient();
   const user = queryClient.getQueryData(['user']);
 
@@ -101,4 +101,4 @@ const TeamSpacePopup = ({ handlePopupClose }) => {
   );
 };
 
-export default TeamSpacePopup;
+export default TeamSpaceCreatePopup;

--- a/src/components/Popup/Mypage/TeamspaceJoinPopup.jsx
+++ b/src/components/Popup/Mypage/TeamspaceJoinPopup.jsx
@@ -1,0 +1,104 @@
+// TeamSpacePopup.js
+import React from 'react';
+import styled from 'styled-components';
+import { useQueryClient } from '@tanstack/react-query';
+import Submitbutton from '../../Button/SubmitButton';
+
+import COLOR from '../../../constants/color';
+import close from '../../../assets/images/close.png';
+import useTeam from '../../../hooks/queries/Team/useTeam';
+import useInput from '../../../hooks/useInput';
+
+const PopupBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+`;
+
+const PopupContainer = styled.div`
+  width: 560px;
+  height: 360px;
+  background-color: ${COLOR.white};
+  padding: 1rem;
+  border-radius: 48px;
+`;
+
+const PopupContent = styled.div`
+  padding: 1.3rem 3.6rem;
+`;
+
+const CloseBtn = styled.img`
+  position: fixed;
+  width: 1rem;
+  height: 1rem;
+  color: black;
+  cursor: pointer;
+  position: relative;
+  top: -1.5rem;
+  right: -33.5rem;
+  z-index: 1001;
+`;
+
+const Title = styled.h2`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2.6rem;
+`;
+
+const SubTitle = styled.div`
+  font-size: 20px;
+  margin: 1.5rem 0;
+`;
+
+const Minibox = styled.input`
+  width: 100%;
+  border: 1px solid ${COLOR.primary.blue};
+  height: 45px;
+  padding: 1rem;
+  margin-bottom: 37px;
+`;
+
+const FlexDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+`;
+
+const TeamSpaceJoinPopup = ({ handlePopupClose }) => {
+  const queryClient = useQueryClient();
+  const user = queryClient.getQueryData(['user']);
+
+  const [teamName, onChangeTeamName] = useInput();
+  const { teamMutation } = useTeam(user ? user.token : '');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    teamMutation({ teamName });
+    handlePopupClose();
+  };
+  return (
+    <PopupBackground>
+      <PopupContainer>
+        <CloseBtn src={close} onClick={handlePopupClose} />
+        <PopupContent>
+          <Title>팀스페이스 참여하기</Title>
+          <SubTitle>코드를 입력해주세요</SubTitle>
+          <Minibox placeholder="코드 입력" onChange={onChangeTeamName} />
+          <FlexDiv>
+            <Submitbutton onClick={handleSubmit}>완료</Submitbutton>
+          </FlexDiv>
+        </PopupContent>
+      </PopupContainer>
+    </PopupBackground>
+  );
+};
+
+export default TeamSpaceJoinPopup;

--- a/src/components/Popup/Mypage/TeamspaceJoinPopup.jsx
+++ b/src/components/Popup/Mypage/TeamspaceJoinPopup.jsx
@@ -75,13 +75,13 @@ const TeamSpaceJoinPopup = ({ handlePopupClose }) => {
   const queryClient = useQueryClient();
   const user = queryClient.getQueryData(['user']);
 
-  const [teamName, onChangeTeamName] = useInput();
-  const { teamMutation } = useTeam(user ? user.token : '');
+  const [teamToken, onChangeTeamToken] = useInput();
+  const { teamJoinMutation } = useTeam(user ? user.token : '');
 
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    teamMutation({ teamName });
+    teamJoinMutation({ teamToken });
     handlePopupClose();
   };
   return (
@@ -91,7 +91,7 @@ const TeamSpaceJoinPopup = ({ handlePopupClose }) => {
         <PopupContent>
           <Title>팀스페이스 참여하기</Title>
           <SubTitle>코드를 입력해주세요</SubTitle>
-          <Minibox placeholder="코드 입력" onChange={onChangeTeamName} />
+          <Minibox placeholder="코드 입력" onChange={onChangeTeamToken} />
           <FlexDiv>
             <Submitbutton onClick={handleSubmit}>완료</Submitbutton>
           </FlexDiv>

--- a/src/components/Popup/Mypage/TeamspacePopup.jsx
+++ b/src/components/Popup/Mypage/TeamspacePopup.jsx
@@ -1,10 +1,13 @@
 // TeamSpacePopup.js
 import React from 'react';
 import styled from 'styled-components';
+import { useQueryClient } from '@tanstack/react-query';
 import Submitbutton from '../../Button/SubmitButton';
 
 import COLOR from '../../../constants/color';
 import close from '../../../assets/images/close.png';
+import useTeam from '../../../hooks/queries/Team/useTeam';
+import useInput from '../../../hooks/useInput';
 
 const PopupBackground = styled.div`
   position: fixed;
@@ -69,6 +72,18 @@ const FlexDiv = styled.div`
 `;
 
 const TeamSpacePopup = ({ handlePopupClose }) => {
+  const queryClient = useQueryClient();
+  const user = queryClient.getQueryData(['user']);
+
+  const [teamName, onChangeTeamName] = useInput();
+  const { teamMutation } = useTeam(user ? user.token : '');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    teamMutation({ teamName });
+    handlePopupClose();
+  };
   return (
     <PopupBackground>
       <PopupContainer>
@@ -76,9 +91,9 @@ const TeamSpacePopup = ({ handlePopupClose }) => {
         <PopupContent>
           <Title>팀스페이스 추가하기</Title>
           <SubTitle>팀스페이스 이름을 입력해주세요.</SubTitle>
-          <Minibox placeholder="최대 N자까지 가능" />
+          <Minibox placeholder="최대 N자까지 가능" onChange={onChangeTeamName} />
           <FlexDiv>
-            <Submitbutton>완료</Submitbutton>
+            <Submitbutton onClick={handleSubmit}>완료</Submitbutton>
           </FlexDiv>
         </PopupContent>
       </PopupContainer>

--- a/src/components/Popup/Recreation/RecreationPopup.jsx
+++ b/src/components/Popup/Recreation/RecreationPopup.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { useQueryClient } from '@tanstack/react-query';
+import Submitbutton from '../../Button/SubmitButton';
+
+import COLOR from '../../../constants/color';
+import close from '../../../assets/images/close.png';
+import useTeam from '../../../hooks/queries/Team/useTeam';
+import Loading from '../../../pages/Loading';
+import Error from '../../../pages/Error';
+import useTeamRecreation from '../../../hooks/queries/Team/useTeamRecreation';
+
+const PopupBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+`;
+
+const PopupContainer = styled.div`
+  width: 560px;
+  height: 360px;
+  background-color: ${COLOR.white};
+  padding: 1rem;
+  border-radius: 48px;
+`;
+
+const PopupContent = styled.div`
+  padding: 1.3rem 3.6rem;
+  height: 100%;
+`;
+
+const CloseBtn = styled.img`
+  position: fixed;
+  width: 1rem;
+  height: 1rem;
+  color: black;
+  cursor: pointer;
+  position: relative;
+  top: -1.5rem;
+  right: -33.5rem;
+  z-index: 1001;
+`;
+
+const Title = styled.h2`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2.6rem;
+`;
+
+const SubTitle = styled.div`
+  font-size: 20px;
+  margin: 1.5rem 0;
+`;
+
+const TeamList = styled.ul`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 3rem;
+`;
+
+const TeamBtn = styled.div`
+  padding: 4px 10px;
+  border: 2px solid ${COLOR.lightGray};
+  border-radius: 16px;
+  text-align: center;
+  width: 148px;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+  &:hover {
+    border: 2px solid ${COLOR.gray};
+    background: ${COLOR.lightGray};
+  }
+
+  ${(props) =>
+    props.active &&
+    css`
+      background-color: ${COLOR.primary.blue};
+      border-color: ${COLOR.primary.blue};
+      color: ${COLOR.white};
+    `}
+`;
+
+const FlexDiv = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const RecreationPopup = ({ pk, handlePopupClose }) => {
+  const queryClient = useQueryClient();
+  const user = queryClient.getQueryData(['user']);
+
+  const {
+    teamQuery: { isLoading: teamIsLoading, error: teamError, data: teams },
+  } = useTeam(user ? user.token : '');
+
+  const { teamRecreationMutation } = useTeamRecreation();
+
+  const handleTeamClick = (teamToken) => {
+    teamRecreationMutation({ teamToken, recreationPk: pk });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    handlePopupClose();
+  };
+  return (
+    <PopupBackground>
+      <PopupContainer>
+        <CloseBtn src={close} onClick={handlePopupClose} />
+        <PopupContent>
+          <Title>팀스페이스 추가하기</Title>
+          <SubTitle>추가할 팀스페이스를 선택해주세요</SubTitle>
+          {teamIsLoading && <Loading />}
+          {teamError && <Error />}
+          <TeamList>
+            {teams &&
+              teams.map((team) => (
+                <TeamBtn
+                  key={team.teamToken}
+                  active={team.teamName === true}
+                  onClick={() => handleTeamClick(team.teamToken)}
+                >
+                  {team.teamName}
+                </TeamBtn>
+              ))}
+          </TeamList>
+          <FlexDiv>
+            <Submitbutton onClick={handleSubmit}>완료</Submitbutton>
+          </FlexDiv>
+        </PopupContent>
+      </PopupContainer>
+    </PopupBackground>
+  );
+};
+
+export default RecreationPopup;

--- a/src/components/Popup/Recreation/RecreationPopup.jsx
+++ b/src/components/Popup/Recreation/RecreationPopup.jsx
@@ -7,8 +7,8 @@ import COLOR from '../../../constants/color';
 import close from '../../../assets/images/close.png';
 import Loading from '../../../pages/Loading';
 import Error from '../../../pages/Error';
-import useTeamRecreationCreate from '../../../hooks/queries/Team/useTeamRecreationCreate';
 import useTeamRecreationIsScrap from '../../../hooks/queries/Team/useTeamRecreationIsScrap';
+import useTeamRecreationScrap from '../../../hooks/queries/Team/useTeamRecreationScrap';
 
 const PopupBackground = styled.div`
   position: fixed;
@@ -106,7 +106,7 @@ const RecreationPopup = ({ pk, handlePopupClose }) => {
     teamRecreationScrapQuery: { isLoading, error, data: teams },
   } = useTeamRecreationIsScrap(user ? user.token : '', pk);
 
-  const { teamRecreationMutation } = useTeamRecreationCreate(user ? user.token : '', pk);
+  const { teamRecreationMutation } = useTeamRecreationScrap(user ? user.token : '', pk);
 
   const handleTeamClick = (teamToken) => {
     teamRecreationMutation({ teamToken, recreationPk: pk });

--- a/src/components/Popup/Recreation/RecreationPopup.jsx
+++ b/src/components/Popup/Recreation/RecreationPopup.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useQueryClient } from '@tanstack/react-query';
 import Submitbutton from '../../Button/SubmitButton';
 
@@ -8,7 +8,7 @@ import close from '../../../assets/images/close.png';
 import useTeam from '../../../hooks/queries/Team/useTeam';
 import Loading from '../../../pages/Loading';
 import Error from '../../../pages/Error';
-import useTeamRecreation from '../../../hooks/queries/Team/useTeamRecreation';
+import useTeamRecreationCreate from '../../../hooks/queries/Team/useTeamRecreationCreate';
 
 const PopupBackground = styled.div`
   position: fixed;
@@ -81,14 +81,6 @@ const TeamBtn = styled.div`
     border: 2px solid ${COLOR.gray};
     background: ${COLOR.lightGray};
   }
-
-  ${(props) =>
-    props.active &&
-    css`
-      background-color: ${COLOR.primary.blue};
-      border-color: ${COLOR.primary.blue};
-      color: ${COLOR.white};
-    `}
 `;
 
 const FlexDiv = styled.div`
@@ -104,7 +96,7 @@ const RecreationPopup = ({ pk, handlePopupClose }) => {
     teamQuery: { isLoading: teamIsLoading, error: teamError, data: teams },
   } = useTeam(user ? user.token : '');
 
-  const { teamRecreationMutation } = useTeamRecreation();
+  const { teamRecreationMutation } = useTeamRecreationCreate(user ? user.token : '');
 
   const handleTeamClick = (teamToken) => {
     teamRecreationMutation({ teamToken, recreationPk: pk });
@@ -127,11 +119,7 @@ const RecreationPopup = ({ pk, handlePopupClose }) => {
           <TeamList>
             {teams &&
               teams.map((team) => (
-                <TeamBtn
-                  key={team.teamToken}
-                  active={team.teamName === true}
-                  onClick={() => handleTeamClick(team.teamToken)}
-                >
+                <TeamBtn key={team.teamToken} onClick={() => handleTeamClick(team.teamToken)}>
                   {team.teamName}
                 </TeamBtn>
               ))}

--- a/src/components/Popup/Recreation/RecreationPopup.jsx
+++ b/src/components/Popup/Recreation/RecreationPopup.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useQueryClient } from '@tanstack/react-query';
 import Submitbutton from '../../Button/SubmitButton';
 
 import COLOR from '../../../constants/color';
 import close from '../../../assets/images/close.png';
-import useTeam from '../../../hooks/queries/Team/useTeam';
 import Loading from '../../../pages/Loading';
 import Error from '../../../pages/Error';
 import useTeamRecreationCreate from '../../../hooks/queries/Team/useTeamRecreationCreate';
+import useTeamRecreationIsScrap from '../../../hooks/queries/Team/useTeamRecreationIsScrap';
 
 const PopupBackground = styled.div`
   position: fixed;
@@ -71,7 +71,9 @@ const TeamBtn = styled.div`
   padding: 4px 10px;
   border: 2px solid ${COLOR.lightGray};
   border-radius: 16px;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 148px;
   cursor: pointer;
   transition:
@@ -81,6 +83,14 @@ const TeamBtn = styled.div`
     border: 2px solid ${COLOR.gray};
     background: ${COLOR.lightGray};
   }
+
+  ${(props) =>
+    props.isScrap &&
+    css`
+      background-color: ${COLOR.primary.blue};
+      color: ${COLOR.white};
+      border: none;
+    `}
 `;
 
 const FlexDiv = styled.div`
@@ -93,10 +103,10 @@ const RecreationPopup = ({ pk, handlePopupClose }) => {
   const user = queryClient.getQueryData(['user']);
 
   const {
-    teamQuery: { isLoading: teamIsLoading, error: teamError, data: teams },
-  } = useTeam(user ? user.token : '');
+    teamRecreationScrapQuery: { isLoading, error, data: teams },
+  } = useTeamRecreationIsScrap(user ? user.token : '', pk);
 
-  const { teamRecreationMutation } = useTeamRecreationCreate(user ? user.token : '');
+  const { teamRecreationMutation } = useTeamRecreationCreate(user ? user.token : '', pk);
 
   const handleTeamClick = (teamToken) => {
     teamRecreationMutation({ teamToken, recreationPk: pk });
@@ -114,12 +124,16 @@ const RecreationPopup = ({ pk, handlePopupClose }) => {
         <PopupContent>
           <Title>팀스페이스 추가하기</Title>
           <SubTitle>추가할 팀스페이스를 선택해주세요</SubTitle>
-          {teamIsLoading && <Loading />}
-          {teamError && <Error />}
+          {isLoading && <Loading />}
+          {error && <Error />}
           <TeamList>
             {teams &&
               teams.map((team) => (
-                <TeamBtn key={team.teamToken} onClick={() => handleTeamClick(team.teamToken)}>
+                <TeamBtn
+                  key={team.teamToken}
+                  onClick={() => handleTeamClick(team.teamToken)}
+                  isScrap={team.isScrap}
+                >
                   {team.teamName}
                 </TeamBtn>
               ))}

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -30,6 +30,7 @@ export const SHOPPINGAPI = {
 export const TEAMAPI = {
   TEAM: `${BASE_URL}/team/teamSpace/`,
   TEAMLODGING: `${BASE_URL}/team/teamSpaceLodging/`,
+  LODGING_IS_SCRAP: `${BASE_URL}/team/teamSpaceLodging/scrapList/`,
   TEAMRECREATION: `${BASE_URL}/team/teamSpaceRecreation/`,
   TEAMSHOPPING: `${BASE_URL}/team/teamSpaceShopping/`,
 };

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -26,3 +26,7 @@ export const SHOPPINGAPI = {
   CREATE: `${BASE_URL}/shopping/create/`,
   LIST: `${BASE_URL}/shopping/shoppingList/`,
 };
+
+export const TEAMAPI = {
+  TEAM: `${BASE_URL}/team/teamSpace/`,
+};

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -31,4 +31,5 @@ export const TEAMAPI = {
   TEAM: `${BASE_URL}/team/teamSpace/`,
   TEAMLODGING: `${BASE_URL}/team/teamSpaceLodging/`,
   TEAMRECREATION: `${BASE_URL}/team/teamSpaceRecreation/`,
+  TEAMSHOPPING: `${BASE_URL}/team/teamSpaceShopping/`,
 };

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -32,5 +32,6 @@ export const TEAMAPI = {
   TEAMLODGING: `${BASE_URL}/team/teamSpaceLodging/`,
   LODGING_IS_SCRAP: `${BASE_URL}/team/teamSpaceLodging/scrapList/`,
   TEAMRECREATION: `${BASE_URL}/team/teamSpaceRecreation/`,
+  RECREATION_IS_SCRAP: `${BASE_URL}/team/teamSpaceRecreation/scrapList/`,
   TEAMSHOPPING: `${BASE_URL}/team/teamSpaceShopping/`,
 };

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -30,4 +30,5 @@ export const SHOPPINGAPI = {
 export const TEAMAPI = {
   TEAM: `${BASE_URL}/team/teamSpace/`,
   TEAMLODGING: `${BASE_URL}/team/teamSpaceLodging/`,
+  TEAMRECREATION: `${BASE_URL}/team/teamSpaceRecreation/`,
 };

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -29,4 +29,5 @@ export const SHOPPINGAPI = {
 
 export const TEAMAPI = {
   TEAM: `${BASE_URL}/team/teamSpace/`,
+  TEAMLODGING: `${BASE_URL}/team/teamSpaceLodging/`,
 };

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -29,6 +29,7 @@ export const SHOPPINGAPI = {
 
 export const TEAMAPI = {
   TEAM: `${BASE_URL}/team/teamSpace/`,
+  JOIN: `${BASE_URL}/team/teamSpace/join/`,
   TEAMLODGING: `${BASE_URL}/team/teamSpaceLodging/`,
   LODGING_IS_SCRAP: `${BASE_URL}/team/teamSpaceLodging/scrapList/`,
   TEAMRECREATION: `${BASE_URL}/team/teamSpaceRecreation/`,

--- a/src/hooks/queries/Team/useTeam.jsx
+++ b/src/hooks/queries/Team/useTeam.jsx
@@ -6,6 +6,16 @@ const useTeam = (token) => {
 
   const teamQuery = useQuery(['teams'], () => teamAPI.list(token));
 
+  const { mutate: teamJoinMutation } = useMutation((payload) => teamAPI.join(payload, token), {
+    onSuccess: (data) => {
+      console.log(data);
+      queryClient.invalidateQueries(['teams']);
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+
   const { mutate: teamMutation } = useMutation((name) => teamAPI.create(name, token), {
     onSuccess: (data) => {
       console.log(data);
@@ -16,7 +26,7 @@ const useTeam = (token) => {
     },
   });
 
-  return { teamQuery, teamMutation };
+  return { teamQuery, teamJoinMutation, teamMutation };
 };
 
 export default useTeam;

--- a/src/hooks/queries/Team/useTeam.jsx
+++ b/src/hooks/queries/Team/useTeam.jsx
@@ -1,0 +1,22 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeam = (token) => {
+  const queryClient = useQueryClient();
+
+  const teamQuery = useQuery(['teams'], () => teamAPI.list(token));
+
+  const { mutate: teamMutation } = useMutation((name) => teamAPI.create(name, token), {
+    onSuccess: (data) => {
+      console.log(data);
+      queryClient.invalidateQueries(['teams']);
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+
+  return { teamQuery, teamMutation };
+};
+
+export default useTeam;

--- a/src/hooks/queries/Team/useTeamLodging.jsx
+++ b/src/hooks/queries/Team/useTeamLodging.jsx
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeamLodging = (token) => {
+  const queryClient = useQueryClient();
+
+  //   const teamLodgingQuery = useQuery(['team', 'lodging'], () => teamAPI.lodgingList(token));
+
+  const { mutate: teamLodgingMutation } = useMutation(
+    (paylod) => teamAPI.lodgingCreate(paylod, token),
+    {
+      onSuccess: (data) => {
+        console.log(data);
+        queryClient.invalidateQueries(['team', 'lodging']);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    },
+  );
+
+  return { teamLodgingMutation };
+};
+
+export default useTeamLodging;

--- a/src/hooks/queries/Team/useTeamLodging.jsx
+++ b/src/hooks/queries/Team/useTeamLodging.jsx
@@ -1,13 +1,15 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
-const useTeamLodging = (token) => {
+const useTeamLodging = (userToken, teamToken = {}) => {
   const queryClient = useQueryClient();
 
-  //   const teamLodgingQuery = useQuery(['team', 'lodging'], () => teamAPI.lodgingList(token));
+  const teamLodgingQuery = useQuery(['team', 'lodging'], () =>
+    teamAPI.lodgingList(userToken, teamToken),
+  );
 
   const { mutate: teamLodgingMutation } = useMutation(
-    (paylod) => teamAPI.lodgingCreate(paylod, token),
+    (paylod) => teamAPI.lodgingCreate(paylod, userToken),
     {
       onSuccess: (data) => {
         console.log(data);
@@ -19,7 +21,7 @@ const useTeamLodging = (token) => {
     },
   );
 
-  return { teamLodgingMutation };
+  return { teamLodgingQuery, teamLodgingMutation };
 };
 
 export default useTeamLodging;

--- a/src/hooks/queries/Team/useTeamLodging.jsx
+++ b/src/hooks/queries/Team/useTeamLodging.jsx
@@ -4,7 +4,7 @@ import teamAPI from '../../../apis/teamAPI';
 const useTeamLodging = (userToken, teamToken = {}) => {
   const queryClient = useQueryClient();
 
-  const teamLodgingQuery = useQuery(['team', 'lodging'], () =>
+  const teamLodgingQuery = useQuery(['team', teamToken, 'lodging'], () =>
     teamAPI.lodgingList(userToken, teamToken),
   );
 
@@ -13,7 +13,7 @@ const useTeamLodging = (userToken, teamToken = {}) => {
     {
       onSuccess: (data) => {
         console.log(data);
-        queryClient.invalidateQueries(['team', 'lodging']);
+        queryClient.invalidateQueries(['team', teamToken, 'lodging']);
       },
       onError: (error) => {
         console.log(error);

--- a/src/hooks/queries/Team/useTeamLodging.jsx
+++ b/src/hooks/queries/Team/useTeamLodging.jsx
@@ -1,27 +1,12 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
 const useTeamLodging = (userToken, teamToken = {}) => {
-  const queryClient = useQueryClient();
-
   const teamLodgingQuery = useQuery(['team', teamToken, 'lodging'], () =>
     teamAPI.lodgingList(userToken, teamToken),
   );
 
-  const { mutate: teamLodgingMutation } = useMutation(
-    (paylod) => teamAPI.lodgingCreate(paylod, userToken),
-    {
-      onSuccess: (data) => {
-        console.log(data);
-        queryClient.invalidateQueries(['team', teamToken, 'lodging']);
-      },
-      onError: (error) => {
-        console.log(error);
-      },
-    },
-  );
-
-  return { teamLodgingQuery, teamLodgingMutation };
+  return { teamLodgingQuery };
 };
 
 export default useTeamLodging;

--- a/src/hooks/queries/Team/useTeamLodgingCreate.jsx
+++ b/src/hooks/queries/Team/useTeamLodgingCreate.jsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
-const useTeamLodgingCreate = (userToken) => {
+const useTeamLodgingCreate = (userToken, lodgingPk) => {
   const queryClient = useQueryClient();
 
   const { mutate: teamLodgingMutation } = useMutation(
@@ -9,7 +9,7 @@ const useTeamLodgingCreate = (userToken) => {
     {
       onSuccess: (data) => {
         console.log(data);
-        queryClient.invalidateQueries(['team', 'lodging']);
+        queryClient.invalidateQueries(['team', lodgingPk, 'lodging']);
       },
       onError: (error) => {
         console.log(error);

--- a/src/hooks/queries/Team/useTeamLodgingCreate.jsx
+++ b/src/hooks/queries/Team/useTeamLodgingCreate.jsx
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeamLodgingCreate = (userToken) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: teamLodgingMutation } = useMutation(
+    (paylod) => teamAPI.lodgingCreate(paylod, userToken),
+    {
+      onSuccess: (data) => {
+        console.log(data);
+        queryClient.invalidateQueries(['team', 'lodging']);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    },
+  );
+
+  return { teamLodgingMutation };
+};
+
+export default useTeamLodgingCreate;

--- a/src/hooks/queries/Team/useTeamLodgingIsScrap.jsx
+++ b/src/hooks/queries/Team/useTeamLodgingIsScrap.jsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
-const useTeamLodgingScrap = (userToken, lodgingPk) => {
+const useTeamLodgingIsScrap = (userToken, lodgingPk) => {
   const teamLodgingScrapQuery = useQuery(['team', lodgingPk, 'lodging'], () =>
     teamAPI.lodgingScrapList(userToken, lodgingPk),
   );
@@ -9,4 +9,4 @@ const useTeamLodgingScrap = (userToken, lodgingPk) => {
   return { teamLodgingScrapQuery };
 };
 
-export default useTeamLodgingScrap;
+export default useTeamLodgingIsScrap;

--- a/src/hooks/queries/Team/useTeamLodgingScrap.jsx
+++ b/src/hooks/queries/Team/useTeamLodgingScrap.jsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeamLodgingScrap = (userToken, lodgingPk) => {
+  const teamLodgingScrapQuery = useQuery(['team', lodgingPk, 'lodging'], () =>
+    teamAPI.lodgingScrapList(userToken, lodgingPk),
+  );
+
+  return { teamLodgingScrapQuery };
+};
+
+export default useTeamLodgingScrap;

--- a/src/hooks/queries/Team/useTeamLodgingScrap.jsx
+++ b/src/hooks/queries/Team/useTeamLodgingScrap.jsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
-const useTeamLodgingCreate = (userToken, lodgingPk) => {
+const useTeamLodgingScrap = (userToken, lodgingPk) => {
   const queryClient = useQueryClient();
 
   const { mutate: teamLodgingMutation } = useMutation(
@@ -20,4 +20,4 @@ const useTeamLodgingCreate = (userToken, lodgingPk) => {
   return { teamLodgingMutation };
 };
 
-export default useTeamLodgingCreate;
+export default useTeamLodgingScrap;

--- a/src/hooks/queries/Team/useTeamRecreation.jsx
+++ b/src/hooks/queries/Team/useTeamRecreation.jsx
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeamRecreation = (token) => {
+  const queryClient = useQueryClient();
+
+  // const teamLodgingQuery = useQuery(['team', 'recreation'], () => teamAPI.recreaitonList(token));
+
+  const { mutate: teamRecreationMutation } = useMutation(
+    (paylod) => teamAPI.recreaitonCreate(paylod, token),
+    {
+      onSuccess: (data) => {
+        console.log(data);
+        queryClient.invalidateQueries(['team', 'recreation']);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    },
+  );
+
+  return { teamRecreationMutation };
+};
+
+export default useTeamRecreation;

--- a/src/hooks/queries/Team/useTeamRecreation.jsx
+++ b/src/hooks/queries/Team/useTeamRecreation.jsx
@@ -1,27 +1,12 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
 const useTeamRecreation = (userToken, teamToken = {}) => {
-  const queryClient = useQueryClient();
-
   const teamRecreationQuery = useQuery(['team', teamToken, 'recreation'], () =>
     teamAPI.recreaitonList(userToken, teamToken),
   );
 
-  const { mutate: teamRecreationMutation } = useMutation(
-    (paylod) => teamAPI.recreaitonCreate(paylod, userToken),
-    {
-      onSuccess: (data) => {
-        console.log(data);
-        queryClient.invalidateQueries(['team', teamToken, 'recreation']);
-      },
-      onError: (error) => {
-        console.log(error);
-      },
-    },
-  );
-
-  return { teamRecreationQuery, teamRecreationMutation };
+  return { teamRecreationQuery };
 };
 
 export default useTeamRecreation;

--- a/src/hooks/queries/Team/useTeamRecreation.jsx
+++ b/src/hooks/queries/Team/useTeamRecreation.jsx
@@ -1,17 +1,19 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
-const useTeamRecreation = (token) => {
+const useTeamRecreation = (userToken, teamToken = {}) => {
   const queryClient = useQueryClient();
 
-  // const teamLodgingQuery = useQuery(['team', 'recreation'], () => teamAPI.recreaitonList(token));
+  const teamRecreationQuery = useQuery(['team', teamToken, 'recreation'], () =>
+    teamAPI.recreaitonList(userToken, teamToken),
+  );
 
   const { mutate: teamRecreationMutation } = useMutation(
-    (paylod) => teamAPI.recreaitonCreate(paylod, token),
+    (paylod) => teamAPI.recreaitonCreate(paylod, userToken),
     {
       onSuccess: (data) => {
         console.log(data);
-        queryClient.invalidateQueries(['team', 'recreation']);
+        queryClient.invalidateQueries(['team', teamToken, 'recreation']);
       },
       onError: (error) => {
         console.log(error);
@@ -19,7 +21,7 @@ const useTeamRecreation = (token) => {
     },
   );
 
-  return { teamRecreationMutation };
+  return { teamRecreationQuery, teamRecreationMutation };
 };
 
 export default useTeamRecreation;

--- a/src/hooks/queries/Team/useTeamRecreationCreate.jsx
+++ b/src/hooks/queries/Team/useTeamRecreationCreate.jsx
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeamRecreationCreate = (userToken) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: teamRecreationMutation } = useMutation(
+    (paylod) => teamAPI.recreaitonCreate(paylod, userToken),
+    {
+      onSuccess: (data) => {
+        console.log(data);
+        queryClient.invalidateQueries(['team', 'recreation']);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    },
+  );
+
+  return { teamRecreationMutation };
+};
+
+export default useTeamRecreationCreate;

--- a/src/hooks/queries/Team/useTeamRecreationCreate.jsx
+++ b/src/hooks/queries/Team/useTeamRecreationCreate.jsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
-const useTeamRecreationCreate = (userToken) => {
+const useTeamRecreationCreate = (userToken, recreationPk) => {
   const queryClient = useQueryClient();
 
   const { mutate: teamRecreationMutation } = useMutation(
@@ -9,7 +9,7 @@ const useTeamRecreationCreate = (userToken) => {
     {
       onSuccess: (data) => {
         console.log(data);
-        queryClient.invalidateQueries(['team', 'recreation']);
+        queryClient.invalidateQueries(['team', recreationPk, 'recreation']);
       },
       onError: (error) => {
         console.log(error);

--- a/src/hooks/queries/Team/useTeamRecreationIsScrap.jsx
+++ b/src/hooks/queries/Team/useTeamRecreationIsScrap.jsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeamRecreationIsScrap = (userToken, recreationPk) => {
+  const teamRecreationScrapQuery = useQuery(['team', recreationPk, 'recreation'], () =>
+    teamAPI.recreationScrapList(userToken, recreationPk),
+  );
+
+  return { teamRecreationScrapQuery };
+};
+
+export default useTeamRecreationIsScrap;

--- a/src/hooks/queries/Team/useTeamRecreationScrap.jsx
+++ b/src/hooks/queries/Team/useTeamRecreationScrap.jsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import teamAPI from '../../../apis/teamAPI';
 
-const useTeamRecreationCreate = (userToken, recreationPk) => {
+const useTeamRecreationScrap = (userToken, recreationPk) => {
   const queryClient = useQueryClient();
 
   const { mutate: teamRecreationMutation } = useMutation(
@@ -20,4 +20,4 @@ const useTeamRecreationCreate = (userToken, recreationPk) => {
   return { teamRecreationMutation };
 };
 
-export default useTeamRecreationCreate;
+export default useTeamRecreationScrap;

--- a/src/hooks/queries/Team/useTeamShopping.jsx
+++ b/src/hooks/queries/Team/useTeamShopping.jsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeamShopping = (userToken, teamToken = {}) => {
+  const teamShoppingQuery = useQuery(['team', teamToken, 'shopping'], () =>
+    teamAPI.shoppingList(userToken, teamToken),
+  );
+
+  return { teamShoppingQuery };
+};
+
+export default useTeamShopping;

--- a/src/hooks/queries/Team/useTeamShoppingCreation.jsx
+++ b/src/hooks/queries/Team/useTeamShoppingCreation.jsx
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import teamAPI from '../../../apis/teamAPI';
+
+const useTeamShoppingCreation = (userToken) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: teamShoppingMutation } = useMutation(
+    (paylod) => teamAPI.shoppingCreate(paylod, userToken),
+    {
+      onSuccess: (data) => {
+        console.log(data);
+        queryClient.invalidateQueries(['team', 'shopping']);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    },
+  );
+
+  return { teamShoppingMutation };
+};
+
+export default useTeamShoppingCreation;

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const router = createBrowserRouter([
       { path: '/recreation/register', element: <RecreationRegistration /> },
       { path: '/shopping', element: <Shopping /> },
       { path: '/mypage', element: <Mypage /> },
-      { path: '/mypageTeamspace', element: <MypageTeamspace /> },
+      { path: '/mypage/:teamToken', element: <MypageTeamspace /> },
       { path: '/mypage', element: <Mypage /> },
       { path: '/createLodging', element: <CreateLodging /> },
     ],

--- a/src/pages/LodgingDetail.jsx
+++ b/src/pages/LodgingDetail.jsx
@@ -29,6 +29,7 @@ const LodgingDetail = () => {
       {lodgingDetail && (
         <>
           <LodgingDetailHeader
+            pk={lodgingDetail.pk}
             name={lodgingDetail.name}
             mainPhoto={lodgingDetail.mainPhoto}
             photos={lodgingDetail.photos}

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -13,8 +13,8 @@ import useRecreationScrapList from '../hooks/queries/Recreation/useRecreationScr
 import Loading from './Loading';
 import Error from './Error';
 import useTeam from '../hooks/queries/Team/useTeam';
-import ShoppingTable from '../components/Common/Shopping/ShoppingTable';
 import useShopping from '../hooks/queries/Shopping/useShopping';
+import ListTable from '../components/Common/Shopping/ListTable';
 
 const mediaSize = 1030;
 
@@ -206,7 +206,7 @@ const MyPage = () => {
           </Flex>
           <SubTitle>장바구니</SubTitle>
           <Flex>
-            <ShoppingTable data={shoppingItems} setShoppingItems={setShoppingItems} />
+            <ListTable data={shoppingItems} setShoppingItems={setShoppingItems} />
           </Flex>
         </ScrapDiv>
       </Container>

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -113,10 +113,10 @@ const MyPage = () => {
     },
   } = useRecreationScrapList(user ? user.token : '');
 
-  const gotoTeamSpace = () => {
-    // useNavigate(`/Teamspace/${pk}`);
-    navigate(`/MypageTeamspace`);
+  const gotoTeamSpace = (teamToken) => {
+    navigate(`/mypage/${teamToken}`);
   };
+
   const gotoMypage = () => {
     navigate(`/Mypage`);
   };
@@ -143,7 +143,9 @@ const MyPage = () => {
             {teamError && <Error />}
             {teams &&
               teams.map((team) => (
-                <TeamspaceButton onClick={gotoTeamSpace}>{team.teamName}</TeamspaceButton>
+                <TeamspaceButton onClick={() => gotoTeamSpace(team.teamToken)}>
+                  {team.teamName}
+                </TeamspaceButton>
               ))}
           </DivTeamlist>
         </TeamspaceDiv>

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -16,10 +16,11 @@ import useTeam from '../hooks/queries/Team/useTeam';
 
 // 전체 여백
 const Container = styled.div`
-  margin: 0 5rem;
-  padding: 0 5rem;
+  width: 100%;
+  max-width: 1280px;
+  margin: auto;
   display: flex;
-  gap: 2.5rem;
+  gap: 1rem;
 `;
 
 const Hrbar = styled.hr`
@@ -29,11 +30,13 @@ const Hrbar = styled.hr`
 
 const TeamspaceDiv = styled.div`
   width: 100%;
+  flex-basis: 20%;
 `;
 
 const ScrapDiv = styled.div`
-  width: 80%;
+  width: 100%;
   padding-top: 4rem;
+  flex-basis: 80%;
 `;
 
 const Title = styled.button`

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -13,6 +13,8 @@ import useRecreationScrapList from '../hooks/queries/Recreation/useRecreationScr
 import Loading from './Loading';
 import Error from './Error';
 import useTeam from '../hooks/queries/Team/useTeam';
+import ShoppingTable from '../components/Common/Shopping/ShoppingTable';
+import useShopping from '../hooks/queries/Shopping/useShopping';
 
 // 전체 여백
 const Container = styled.div`
@@ -49,7 +51,7 @@ const Title = styled.button`
 
 const SubTitle = styled.div`
   font-size: 24px;
-  margin: 2rem 0;
+  margin: 5rem 0 2rem 0;
 `;
 
 const Flex = styled.div`
@@ -115,6 +117,11 @@ const MyPage = () => {
       data: recreationScrapList,
     },
   } = useRecreationScrapList(user ? user.token : '');
+
+  const {
+    shoppingQuery: { data: shoppingList },
+  } = useShopping(user ? user.token : '');
+  const [shoppingItems, setShoppingItems] = useState(shoppingList || []);
 
   const gotoTeamSpace = (teamToken, teamName) => {
     navigate(`/mypage/${teamToken}`, { state: teamName });
@@ -187,7 +194,9 @@ const MyPage = () => {
               ))}
           </Flex>
           <SubTitle>장바구니</SubTitle>
-          <Flex>장바구니 컴포넌트</Flex>
+          <Flex>
+            <ShoppingTable data={shoppingItems} setShoppingItems={setShoppingItems} />
+          </Flex>
         </ScrapDiv>
       </Container>
     </>

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -16,7 +16,6 @@ import useTeam from '../hooks/queries/Team/useTeam';
 import ShoppingTable from '../components/Common/Shopping/ShoppingTable';
 import useShopping from '../hooks/queries/Shopping/useShopping';
 
-// 전체 여백
 const Container = styled.div`
   width: 100%;
   max-width: 1280px;
@@ -36,7 +35,7 @@ const TeamspaceDiv = styled.div`
 `;
 
 const ScrapDiv = styled.div`
-  width: 100%;
+  width: 170px;
   padding-top: 4rem;
   flex-basis: 80%;
 `;
@@ -77,8 +76,8 @@ const TeamspaceButton = styled.button`
   background: transparent;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    border 0.2s;
+    background-color 0.5s,
+    border 0.5s;
 
   &:hover {
     background-color: ${COLOR.lightGray};
@@ -92,7 +91,7 @@ const TeamspaceButton = styled.button`
 // 팀스페이스 리스트
 const DivTeamlist = styled.div`
   display: flex;
-  gap: 10px;
+  gap: 1rem;
   flex-direction: column;
 `;
 

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -116,8 +116,8 @@ const MyPage = () => {
     },
   } = useRecreationScrapList(user ? user.token : '');
 
-  const gotoTeamSpace = (teamToken) => {
-    navigate(`/mypage/${teamToken}`);
+  const gotoTeamSpace = (teamToken, teamName) => {
+    navigate(`/mypage/${teamToken}`, { state: teamName });
   };
 
   const gotoMypage = () => {
@@ -146,7 +146,7 @@ const MyPage = () => {
             {teamError && <Error />}
             {teams &&
               teams.map((team) => (
-                <TeamspaceButton onClick={() => gotoTeamSpace(team.teamToken)}>
+                <TeamspaceButton onClick={() => gotoTeamSpace(team.teamToken, team.teamName)}>
                   {team.teamName}
                 </TeamspaceButton>
               ))}

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -12,6 +12,7 @@ import useLodgingScrapList from '../hooks/queries/Lodging/useLodgingScrapList';
 import useRecreationScrapList from '../hooks/queries/Recreation/useRecreationScrapList';
 import Loading from './Loading';
 import Error from './Error';
+import useTeam from '../hooks/queries/Team/useTeam';
 
 // 전체 여백
 const Container = styled.div`
@@ -98,6 +99,10 @@ const MyPage = () => {
   const navigate = useNavigate();
 
   const {
+    teamQuery: { isLoading: teamIsLoading, error: teamError, data: teams },
+  } = useTeam(user ? user.token : '');
+
+  const {
     lodgingScrapQuery: { isLoading: lodgingIsLoading, error: lodgingError, data: lodgingScrapList },
   } = useLodgingScrapList(user ? user.token : '');
   const {
@@ -134,11 +139,12 @@ const MyPage = () => {
           <DivTeamlist>
             <TeamspacePlus onClick={handleTeamspacePlusClick}>팀 스페이스 +</TeamspacePlus>
             {IspopupVisivle && <TeamspacePopup handlePopupClose={handlePopupClose} />}
-            <TeamspaceButton onClick={gotoTeamSpace}>국민대스페이스</TeamspaceButton>
-            <TeamspaceButton>동아리스페이스</TeamspaceButton>
-            <TeamspaceButton>동아리스페이스</TeamspaceButton>
-            <TeamspaceButton>동아리스페이스</TeamspaceButton>
-            <TeamspaceButton>동아리스페이스</TeamspaceButton>
+            {teamIsLoading && <Loading />}
+            {teamError && <Error />}
+            {teams &&
+              teams.map((team) => (
+                <TeamspaceButton onClick={gotoTeamSpace}>{team.teamName}</TeamspaceButton>
+              ))}
           </DivTeamlist>
         </TeamspaceDiv>
         <ScrapDiv>

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -7,7 +7,6 @@ import COLOR from '../constants/color';
 import BestlocationCard from '../components/Card/BestlocationCard';
 // import BagCard from '../components/Card/BagCard';
 import RecreationCard from '../components/Card/RecreationCard';
-import TeamspacePopup from '../components/Popup/Mypage/TeamspacePopup';
 import useLodgingScrapList from '../hooks/queries/Lodging/useLodgingScrapList';
 import useRecreationScrapList from '../hooks/queries/Recreation/useRecreationScrapList';
 import Loading from './Loading';
@@ -15,6 +14,8 @@ import Error from './Error';
 import useTeam from '../hooks/queries/Team/useTeam';
 import useShopping from '../hooks/queries/Shopping/useShopping';
 import ListTable from '../components/Common/Shopping/ListTable';
+import TeamSpaceCreatePopup from '../components/Popup/Mypage/TeamspaceCreatePopup';
+import TeamSpaceJoinPopup from '../components/Popup/Mypage/TeamspaceJoinPopup';
 
 const mediaSize = 1030;
 
@@ -111,7 +112,9 @@ const MyPage = () => {
   const queryClient = useQueryClient();
   const user = queryClient.getQueryData(['user']);
 
-  const [IspopupVisivle, setIspopupVisivle] = useState(false);
+  const [IsCreatepopupVisivle, setIsCreatepopupVisivle] = useState(false);
+  const [IsJoinpopupVisivle, setIsJoinpopupVisivle] = useState(false);
+
   const navigate = useNavigate();
 
   const {
@@ -142,12 +145,20 @@ const MyPage = () => {
     navigate(`/Mypage`);
   };
 
-  const handleTeamspacePlusClick = () => {
-    setIspopupVisivle(true);
+  const handleTeamspaceCreateClick = () => {
+    setIsCreatepopupVisivle(true);
   };
 
-  const handlePopupClose = () => {
-    setIspopupVisivle(false);
+  const handleCreatePopupClose = () => {
+    setIsCreatepopupVisivle(false);
+  };
+
+  const handleTeamspaceJoinClick = () => {
+    setIsJoinpopupVisivle(true);
+  };
+
+  const handleJoinPopupClose = () => {
+    setIsJoinpopupVisivle(false);
   };
 
   return (
@@ -158,8 +169,13 @@ const MyPage = () => {
           <Title onClick={gotoMypage}>개인 스페이스</Title>
           <SubTitle>팀 스페이스</SubTitle>
           <DivTeamlist>
-            <TeamspacePlus onClick={handleTeamspacePlusClick}>팀 스페이스 +</TeamspacePlus>
-            {IspopupVisivle && <TeamspacePopup handlePopupClose={handlePopupClose} />}
+            <TeamspacePlus onClick={handleTeamspaceCreateClick}>팀 스페이스 생성</TeamspacePlus>
+            <TeamspacePlus onClick={handleTeamspaceJoinClick}>팀 스페이스 참가</TeamspacePlus>
+
+            {IsCreatepopupVisivle && (
+              <TeamSpaceCreatePopup handlePopupClose={handleCreatePopupClose} />
+            )}
+            {IsJoinpopupVisivle && <TeamSpaceJoinPopup handlePopupClose={handleJoinPopupClose} />}
             {teamIsLoading && <Loading />}
             {teamError && <Error />}
             {teams &&

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -13,13 +13,15 @@ import useTeam from '../hooks/queries/Team/useTeam';
 import Loading from './Loading';
 import Error from './Error';
 import useTeamLodging from '../hooks/queries/Team/useTeamLodging';
+import useTeamRecreation from '../hooks/queries/Team/useTeamRecreation';
 
 // 전체 여백
 const Container = styled.div`
-  margin: 0 5rem;
-  padding: 0 5rem;
+  width: 100%;
+  max-width: 1280px;
+  margin: auto;
   display: flex;
-  gap: 2.5rem;
+  gap: 1rem;
 `;
 
 const Hrbar = styled.hr`
@@ -29,11 +31,13 @@ const Hrbar = styled.hr`
 
 const TeamspaceDiv = styled.div`
   width: 100%;
+  flex-basis: 20%;
 `;
 
 const ScrapDiv = styled.div`
-  width: 80%;
+  width: 100%;
   padding-top: 4rem;
+  flex-basis: 80%;
 `;
 
 const Title = styled.button`
@@ -190,7 +194,6 @@ const MypageTeamspace = () => {
   const navigate = useNavigate();
 
   const { teamToken } = useParams();
-  console.log(teamToken);
 
   const queryClient = useQueryClient();
   const user = queryClient.getQueryData(['user']);
@@ -202,6 +205,14 @@ const MypageTeamspace = () => {
   const {
     teamLodgingQuery: { isLoading: lodgingLoading, error: lodgingError, data: lodgings },
   } = useTeamLodging(user ? user.token : '', { teamToken });
+
+  const {
+    teamRecreationQuery: {
+      isLoading: recreationLoading,
+      error: recreationError,
+      data: recreations,
+    },
+  } = useTeamRecreation(user ? user.token : '', { teamToken });
 
   const gotoTeamSpace = (teamToken) => {
     navigate(`/mypage/${teamToken}`);
@@ -335,11 +346,20 @@ const MypageTeamspace = () => {
           </Flex>
           <SubTitle>공유한 레크레이션</SubTitle>
           <Flex>
-            <RecreationCard />
-            <RecreationCard />
-            <RecreationCard />
-            <RecreationCard />
-            <RecreationCard />
+            {recreationLoading && <Loading />}
+            {recreationError && <Error />}
+            {recreations &&
+              recreations.map((recreation) => (
+                <RecreationCard
+                  key={recreation.pk}
+                  pk={recreation.pk}
+                  name={recreation.name}
+                  price={recreation.price}
+                  mainPhoto={recreation.mainPhoto}
+                  avgScore={recreation.avgScore}
+                  isScrap={recreation.isScrap}
+                />
+              ))}
           </Flex>
           <SubTitle>장바구니</SubTitle>
           <Flex>장바구니 컴포넌트</Flex>

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -351,12 +351,11 @@ const MypageTeamspace = () => {
             {recreations &&
               recreations.map((recreation) => (
                 <RecreationCard
-                  key={recreation.pk}
                   pk={recreation.pk}
                   name={recreation.name}
-                  price={recreation.price}
-                  mainPhoto={recreation.mainPhoto}
-                  avgScore={recreation.avgScore}
+                  photo={recreation.photo}
+                  headCountMin={recreation.headCountMin}
+                  headCountMax={recreation.headCountMax}
                   isScrap={recreation.isScrap}
                 />
               ))}

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -208,7 +208,7 @@ const MypageTeamspace = () => {
   };
 
   const gotoMypage = () => {
-    navigate(`/Mypage`);
+    navigate(`/mypage`);
   };
 
   const handleTeamspacePlusClick = () => {

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import CopyToClipboard from 'react-copy-to-clipboard';
@@ -15,7 +15,6 @@ import Error from './Error';
 import useTeamLodging from '../hooks/queries/Team/useTeamLodging';
 import useTeamRecreation from '../hooks/queries/Team/useTeamRecreation';
 
-// 전체 여백
 const Container = styled.div`
   width: 100%;
   max-width: 1280px;
@@ -35,7 +34,7 @@ const TeamspaceDiv = styled.div`
 `;
 
 const ScrapDiv = styled.div`
-  width: 100%;
+  width: 170px;
   padding-top: 4rem;
   flex-basis: 80%;
 `;
@@ -95,7 +94,7 @@ const TeamspaceButton = styled.button`
 // 팀스페이스 리스트
 const DivTeamlist = styled.div`
   display: flex;
-  gap: 12px;
+  gap: 1rem;
   flex-direction: column;
 `;
 
@@ -192,12 +191,12 @@ const Notification = styled.div`
 const MypageTeamspace = () => {
   const [IspopupVisivle, setIspopupVisivle] = useState(false);
   const [isDeletePopupVisible, setIsDeletePopupVisible] = useState(false);
-  const [inviteCode, setInviteCode] = useState('ABCD1234');
   const [showNotification, setShowNotification] = useState(false); // Notification state
   const navigate = useNavigate();
   const { state: teamName } = useLocation();
 
   const { teamToken } = useParams();
+  const inviteCode = teamToken;
 
   const queryClient = useQueryClient();
   const user = queryClient.getQueryData(['user']);
@@ -256,25 +255,6 @@ const MypageTeamspace = () => {
       setShowNotification(false);
     }, 3000);
   };
-
-  // api 연결 예정
-  const fetchInviteCode = async () => {
-    try {
-      const response = await fetch('');
-      if (response.ok) {
-        const data = await response.json();
-        setInviteCode(data.inviteCode);
-      } else {
-        console.error('실패');
-      }
-    } catch (error) {
-      console.error('에러:', error);
-    }
-  };
-
-  useEffect(() => {
-    fetchInviteCode();
-  }, []);
 
   return (
     <>

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -50,7 +50,7 @@ const Title = styled.button`
 
 const SubTitle = styled.div`
   font-size: 24px;
-  margin: 2rem 0;
+  margin: 5rem 0 2rem 0;
   font-weight: 700;
 `;
 

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import CopyToClipboard from 'react-copy-to-clipboard';
@@ -14,6 +14,8 @@ import Loading from './Loading';
 import Error from './Error';
 import useTeamLodging from '../hooks/queries/Team/useTeamLodging';
 import useTeamRecreation from '../hooks/queries/Team/useTeamRecreation';
+import useTeamShopping from '../hooks/queries/Team/useTeamShopping';
+import ListTable from '../components/Common/Shopping/ListTable';
 
 const mediaSize = 1030;
 
@@ -229,6 +231,12 @@ const MypageTeamspace = () => {
     },
   } = useTeamRecreation(user ? user.token : '', { teamToken });
 
+  const {
+    teamShoppingQuery: { isLoading: shoppingLoading, error: shoppingError, data: teamShoppingList },
+  } = useTeamShopping(user ? user.token : '', { teamToken });
+
+  const [shoppingItems, setShoppingItems] = useState(teamShoppingList || []);
+
   const gotoTeamSpace = (teamToken, teamName) => {
     navigate(`/mypage/${teamToken}`, { state: teamName });
   };
@@ -267,6 +275,10 @@ const MypageTeamspace = () => {
       setShowNotification(false);
     }, 3000);
   };
+
+  useEffect(() => {
+    setShoppingItems(teamShoppingList || []);
+  }, [teamShoppingList]);
 
   return (
     <>
@@ -360,7 +372,13 @@ const MypageTeamspace = () => {
               ))}
           </Flex>
           <SubTitle>장바구니</SubTitle>
-          <Flex>장바구니 컴포넌트</Flex>
+          <Flex>
+            {shoppingLoading && <Loading />}
+            {shoppingError && <Error />}
+            {teamShoppingList && (
+              <ListTable data={shoppingItems} setShoppingItems={setShoppingItems} />
+            )}
+          </Flex>
         </ScrapDiv>
       </Container>
     </>

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -7,7 +7,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import COLOR from '../constants/color';
 import BestlocationCard from '../components/Card/BestlocationCard';
 import RecreationCard from '../components/Card/RecreationCard';
-import TeamspacePopup from '../components/Popup/Mypage/TeamspacePopup';
 import DeleteSharePopup from '../components/Popup/Mypage/DeleteSharePopup';
 import useTeam from '../hooks/queries/Team/useTeam';
 import Loading from './Loading';
@@ -16,6 +15,8 @@ import useTeamLodging from '../hooks/queries/Team/useTeamLodging';
 import useTeamRecreation from '../hooks/queries/Team/useTeamRecreation';
 import useTeamShopping from '../hooks/queries/Team/useTeamShopping';
 import ListTable from '../components/Common/Shopping/ListTable';
+import TeamSpaceCreatePopup from '../components/Popup/Mypage/TeamspaceCreatePopup';
+import TeamSpaceJoinPopup from '../components/Popup/Mypage/TeamspaceJoinPopup';
 
 const mediaSize = 1030;
 
@@ -203,7 +204,8 @@ const Notification = styled.div`
 `;
 
 const MypageTeamspace = () => {
-  const [IspopupVisivle, setIspopupVisivle] = useState(false);
+  const [IsCreatepopupVisivle, setIsCreatepopupVisivle] = useState(false);
+  const [IsJoinpopupVisivle, setIsJoinpopupVisivle] = useState(false);
   const [isDeletePopupVisible, setIsDeletePopupVisible] = useState(false);
   const [showNotification, setShowNotification] = useState(false); // Notification state
   const navigate = useNavigate();
@@ -245,27 +247,34 @@ const MypageTeamspace = () => {
     navigate(`/mypage`);
   };
 
-  const handleTeamspacePlusClick = () => {
-    setIspopupVisivle(true);
-    console.log('잘 됨');
-  };
-
   const handleDeleteClick = () => {
     setIsDeletePopupVisible(true);
     console.log('잘 됨');
   };
 
-  const handlePopupClose = () => {
-    setIspopupVisivle(false);
+  const handleCancelClose = () => {
+    setIsDeletePopupVisible(false);
+  };
+
+  const handleTeamspaceCreateClick = () => {
+    setIsCreatepopupVisivle(true);
+  };
+
+  const handleCreatePopupClose = () => {
+    setIsCreatepopupVisivle(false);
+  };
+
+  const handleTeamspaceJoinClick = () => {
+    setIsJoinpopupVisivle(true);
+  };
+
+  const handleJoinPopupClose = () => {
+    setIsJoinpopupVisivle(false);
   };
 
   const handleDeleteClose = () => {
     setIsDeletePopupVisible(false);
     // 팀스페이스 삭제하는 api 구현
-  };
-
-  const handleCancelClose = () => {
-    setIsDeletePopupVisible(false);
   };
 
   // 복사가 성공적으로 이루어질 때
@@ -289,8 +298,12 @@ const MypageTeamspace = () => {
           <Title onClick={gotoMypage}>개인 스페이스</Title>
           <SubTitle>팀 스페이스</SubTitle>
           <DivTeamlist>
-            <TeamspacePlus onClick={handleTeamspacePlusClick}>팀 스페이스 +</TeamspacePlus>
-            {IspopupVisivle && <TeamspacePopup handlePopupClose={handlePopupClose} />}
+            <TeamspacePlus onClick={handleTeamspaceCreateClick}>팀 스페이스 생성</TeamspacePlus>
+            <TeamspacePlus onClick={handleTeamspaceJoinClick}>팀 스페이스 참가</TeamspacePlus>{' '}
+            {IsCreatepopupVisivle && (
+              <TeamSpaceCreatePopup handlePopupClose={handleCreatePopupClose} />
+            )}
+            {IsJoinpopupVisivle && <TeamSpaceJoinPopup handlePopupClose={handleJoinPopupClose} />}
             {teamIsLoading && <Loading />}
             {teamError && <Error />}
             {teams &&

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -233,7 +233,7 @@ const MypageTeamspace = () => {
 
   const {
     teamShoppingQuery: { isLoading: shoppingLoading, error: shoppingError, data: teamShoppingList },
-  } = useTeamShopping(user ? user.token : '', { teamToken });
+  } = useTeamShopping(user ? user.token : '', teamToken);
 
   const [shoppingItems, setShoppingItems] = useState(teamShoppingList || []);
 

--- a/src/pages/MypageTeamspace.jsx
+++ b/src/pages/MypageTeamspace.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
-import { useNavigate, useParams } from 'react-router-dom';
+import styled, { css } from 'styled-components';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
 import { useQueryClient } from '@tanstack/react-query';
@@ -41,11 +41,11 @@ const ScrapDiv = styled.div`
 `;
 
 const Title = styled.button`
-  font-size: 25px;
-  font-weight: 700;
+  font-size: 1.5rem;
+  font-weight: 400;
   margin: 3rem 0 10rem 0;
-  border-bottom: 1.4px solid ${COLOR.primary.lightBlue};
   width: 140px;
+  color: ${COLOR.gray};
 `;
 
 const SubTitle = styled.div`
@@ -77,16 +77,19 @@ const TeamspaceButton = styled.button`
   background: transparent;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    border 0.2s;
+    background-color 0.5s,
+    border 0.5s;
 
   &:hover {
     background-color: ${COLOR.lightGray};
   }
 
-  &:active {
-    border: 3px solid ${COLOR.primary.blue};
-  }
+  ${(props) =>
+    props.active &&
+    css`
+      border: 2px solid ${COLOR.blue};
+      font-weight: bold;
+    `}
 `;
 
 // 팀스페이스 리스트
@@ -192,6 +195,7 @@ const MypageTeamspace = () => {
   const [inviteCode, setInviteCode] = useState('ABCD1234');
   const [showNotification, setShowNotification] = useState(false); // Notification state
   const navigate = useNavigate();
+  const { state: teamName } = useLocation();
 
   const { teamToken } = useParams();
 
@@ -214,8 +218,8 @@ const MypageTeamspace = () => {
     },
   } = useTeamRecreation(user ? user.token : '', { teamToken });
 
-  const gotoTeamSpace = (teamToken) => {
-    navigate(`/mypage/${teamToken}`);
+  const gotoTeamSpace = (teamToken, teamName) => {
+    navigate(`/mypage/${teamToken}`, { state: teamName });
   };
 
   const gotoMypage = () => {
@@ -287,7 +291,10 @@ const MypageTeamspace = () => {
             {teamError && <Error />}
             {teams &&
               teams.map((team) => (
-                <TeamspaceButton onClick={() => gotoTeamSpace(team.teamToken)}>
+                <TeamspaceButton
+                  active={teamToken === team.teamToken}
+                  onClick={() => gotoTeamSpace(team.teamToken, team.teamName)}
+                >
                   {team.teamName}
                 </TeamspaceButton>
               ))}
@@ -295,7 +302,7 @@ const MypageTeamspace = () => {
         </TeamspaceDiv>
         <ScrapDiv>
           <TNameDiv>
-            <SubTitle>Teamspace name</SubTitle>
+            <SubTitle>{teamName}</SubTitle>
             <ButtonDiv>
               <DeleteButton onClick={handleDeleteClick}>Delete</DeleteButton>
               {isDeletePopupVisible && (

--- a/src/pages/Shopping.jsx
+++ b/src/pages/Shopping.jsx
@@ -131,6 +131,8 @@ const Shopping = () => {
   const queryClient = useQueryClient();
   const user = queryClient.getQueryData(['user']);
 
+  const [selectedSpace, setSelectedSpace] = useState('개인 스페이스');
+
   const {
     shoppingQuery: { data: shoppingList },
   } = useShopping(user ? user.token : '');
@@ -164,11 +166,9 @@ const Shopping = () => {
   };
   const handleScroll = () => {
     const checklist = document.getElementById('checklist');
-    console.log(window.innerWidth);
 
     if (checklist) {
       const scrollTop = window.scrollY || window.pageYOffset;
-      console.log('scrollTop: ', scrollTop);
       const maxScrollTop = 500;
       if (scrollTop + 200 <= maxScrollTop) {
         checklist.style.position = 'absolute';
@@ -214,8 +214,12 @@ const Shopping = () => {
           </Container>
         </ShoppingLayout>
         <Checklist id="checklist">
-
-          <ShoppingTable data={shoppingItems} setShoppingItems={setShoppingItems} />
+          <ShoppingTable
+            data={shoppingItems}
+            setShoppingItems={setShoppingItems}
+            selectedSpace={selectedSpace}
+            setSelectedSpace={setSelectedSpace}
+          />
         </Checklist>
       </Flex>
     </>


### PR DESCRIPTION
## 작업 내용

1. 팀 스페이스 생성 / 참여하고 속해있는 팀스페이스 목록 가져오기
<img width="197" alt="스크린샷 2023-08-11 오후 2 50 14" src="https://github.com/MT-Go-likelion/MT-Go-front/assets/66055587/95a6ae17-cdae-4549-abc5-0e7b2d05ac4c">

2. 팀 스페이스에 숙소, 레크레이션 추가하는 화면에서 스크랩되어 있는지 여부 보여주고, 원하는 팀 스페이스에 추가하는 기능 (버튼 누르면 UI도 바로 적용됩니다)
![스크린샷 2023-08-11 오후 2 56 19](https://github.com/MT-Go-likelion/MT-Go-front/assets/66055587/62129218-a2f6-4cd5-a087-a1aff40bf871)

3. 장보기 페이지에서 목록들 담고 팀스페이스에 추가하기
![스크린샷 2023-08-11 오후 3 05 23](https://github.com/MT-Go-likelion/MT-Go-front/assets/66055587/a3ac15f8-9572-40ce-a33f-582b091c0fba)


4. 마이페이지 팀스페이스 탭 눌렀을 때 UI로 표시해주기
![스크린샷 2023-08-11 오후 2 57 20](https://github.com/MT-Go-likelion/MT-Go-front/assets/66055587/a244ee95-7eae-4322-82a0-c82433f49e2d)

5. 팀스페이스 숙소, 레크레이션, 장보기 리스트 보여주기
![스크린샷 2023-08-11 오후 2 56 56](https://github.com/MT-Go-likelion/MT-Go-front/assets/66055587/33476ea6-a1fe-4ccb-972b-448bee679f79)
![스크린샷 2023-08-11 오후 2 57 00](https://github.com/MT-Go-likelion/MT-Go-front/assets/66055587/d7657436-5b8e-4b5c-9242-a4dae45c0558)

## 기타 사항
- 따로 뺴주신 ListTable 컴포넌트에 추가하는 버튼이 없는데, 추가해놔주세요!
![스크린샷 2023-08-11 오후 2 59 25](https://github.com/MT-Go-likelion/MT-Go-front/assets/66055587/143cd7de-9f84-4cb8-967c-6973fb3b2fd6)

- 그리고 장보기 페이지에서 select box로 옵션 선택해서 리스트들 제출하는 POST api는 잘 작동하는데, 선택했을 때 해당 팀 스페이스에 해당하는 리스트들을 가져오는 것을 시도했는데 계속 실패했습니다.. 개인스페이스랑 팀스페이스 호출하는 api가 다른데 Shopping 컴포넌트에서 하나의 state로 관리하는 로직으로 구현이 되어 있어서 그런 것 같아요. 아마도 이거 해결하려면 개인스페이스랑 팀스페이스 체크리스트 아에 따로 2개 만들어야 해결이 가능해보이긴하는데, 일단 이 상태로 올리고 나중에 체크리스트 2개 따로 만드는 걸로 일단 수정할게요.

- 이후  팀스페이스 관련해서 추가 작업할 내용 : 팀스페이스에 해당하는 유저 목록 가져오기 / 장보기 페이지에서 개인, 팀스페이스 체크리스트 따로 만들어서 불러오기
